### PR TITLE
Removed unneeded getName function

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,11 +42,6 @@ HttpWindowBlinds.prototype = {
 		this.log("Identify requested!");
 		callback(null);
 	},
-	
-	getName: function(callback) {
-		this.log("getName :", this.name);
-		callback(null, this.name);
-	},
 
 	getCurrentPosition: function(callback) {
 		var ops = {
@@ -115,10 +110,6 @@ HttpWindowBlinds.prototype = {
 			.setCharacteristic(Characteristic.Manufacturer, "Peter Chodyra")
 			.setCharacteristic(Characteristic.Model, "HTTP Window Blinds")
 			.setCharacteristic(Characteristic.SerialNumber, "HWB02");
-
-		this.service
-			.getCharacteristic(Characteristic.Name)
-			.on('get', this.getName.bind(this));
 
 		this.service
 			.getCharacteristic(Characteristic.CurrentPosition)


### PR DESCRIPTION
The getName function creates a empty characteristic called name that breaks homebridge-alexa.

{
        "iid": 12,
        "type": "00000023-0000-1000-8000-0026BB765291",
        "perms": ["pr"],
        "format": "string",
        "value": "",
        "description": "Name"
      }],